### PR TITLE
Adding CloudWatch example

### DIFF
--- a/assets/example.js
+++ b/assets/example.js
@@ -162,5 +162,38 @@ service:
       exporters:
       - logging
       - otlp/lightstep
+`,
+    "cloudwatch-rec":  `receivers:
+    otlp:
+      protocols:
+        grpc:
+
+processors:
+  batch:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 50
+    spike_limit_percentage: 30
+
+exporters:
+  awsemf:
+    region: 'us-west-2'
+    resource_to_telemetry_conversion:
+      enabled: true
+
+extensions:
+  health_check:
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers:
+      - otlp
+      processors:
+      - memory_limiter
+      - batch
+      exporters:
+      - awsemf   
 `
 }

--- a/assets/index.html
+++ b/assets/index.html
@@ -40,6 +40,7 @@
                             <option value="" selected="selected"></option>
                             <option value="otlp">Simple OTLP Receiver and Exporter</option>
                             <option value="lightstep-rec">OTLP Metrics and Traces to Lightstep</option>
+                            <option value="cloudwatch-rec">OTLP Metrics to CloudWatch</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
This pull request adds an example config to send OTLP metrics to CloudWatch. The example config is taken from the emf exporter readme:

https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awsemfexporter